### PR TITLE
Cdash04 profiling NCBI GI fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ NAME = Distributed Pumpkin
 MPICXX = mpicxx
 
 # CXXFLAGS can be changed by the end user with make CXXFLAGS="..."
-CXXFLAGS = -O3 -std=c++11 -Wall -g
+CXXFLAGS = -O3 -std=c++98 -Wall -g
 
 RM = rm
 CD = cd

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ NAME = Distributed Pumpkin
 MPICXX = mpicxx
 
 # CXXFLAGS can be changed by the end user with make CXXFLAGS="..."
-CXXFLAGS = -O3 -std=c++98 -Wall -g
+CXXFLAGS = -O3 -std=c++11 -Wall -g
 
 RM = rm
 CD = cd
@@ -181,7 +181,7 @@ showOptions:
 	$(Q)echo LDFLAGS = $(LDFLAGS)
 	$(Q)echo ""
 	$(Q)touch showOptions
-	
+
 # how to make Ray
 Ray: code/application_core/ray_main.o libRay.a libRayPlatform.a
 	$(Q)$(ECHO) "  LD $@"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-VERSION = 2
-PATCHLEVEL = 3
-SUBLEVEL = 2
-EXTRAVERSION = -devel
+VERSION = 3
+PATCHLEVEL = 0
+SUBLEVEL = 1
+EXTRAVERSION = -rc
 NAME = Distributed Pumpkin
 
 # Like in Linux, stuff that must be propagated to

--- a/code/Searcher/SearchDirectory.cpp
+++ b/code/Searcher/SearchDirectory.cpp
@@ -638,62 +638,65 @@ bool SearchDirectory::hasCurrentSequenceIdentifier(){
 }
 
 PhysicalKmerColor SearchDirectory::getCurrentSequenceIdentifier(){
-    //int count=0;
-    int i=0;
-    string content;
-    string currentSequenceHeader=m_currentSequenceHeader;
-    //if the old NCBI files are used :
-    if (currentSequenceHeader.find(">gi|") != string::npos ) {
-        int count = 0;
-        int j = 0;
-        while (i < (int) currentSequenceHeader.length() && count < 4) {
-            if (currentSequenceHeader[i] == '|'){
-                count++;
-                if (count == 3) j = i;
-                }
-            i++;
-        }
-        if (count != 4)
-            return DUMMY_IDENTIFIER; // return a dummy identifier
-        content = currentSequenceHeader.substr(j + 1, i - j - 2);
-    }
-    //if the new NCBI files are used :
-    else {
-        while (i < (int) currentSequenceHeader.length() && currentSequenceHeader[i] != ' ') {
-            i++;
-        }
-        if(i==currentSequenceHeader.length())
-            return DUMMY_IDENTIFIER; // return a dummy identifier
-        content=currentSequenceHeader.substr(1,i-1);
-    }
+
+	//int count=0;
+	int i=0;
+	string content;
+	string currentSequenceHeader=m_currentSequenceHeader;
+
+	//if the old NCBI files are used :
+	if (currentSequenceHeader.find(">gi|") != string::npos ) {
+		int count = 0;
+		int j = 0;
+		while (i < (int) currentSequenceHeader.length() && count < 4) {
+			if (currentSequenceHeader[i] == '|'){
+				count++;
+				if (count == 3) j = i;
+			}
+			i++;
+		}
+		if (count != 4)
+			return DUMMY_IDENTIFIER; // return a dummy identifier
+		content = currentSequenceHeader.substr(j + 1, i - j - 2);
+	}
+	//if the new NCBI files are used :
+	else {
+		while (i < (int) currentSequenceHeader.length() && currentSequenceHeader[i] != ' ') {
+			i++;
+		}
+		if(i==currentSequenceHeader.length())
+			return DUMMY_IDENTIFIER; // return a dummy identifier
+		content=currentSequenceHeader.substr(1,i-1);
+	}
 
 
-    // >gi|1234|
-    // 0123456789
-    //
-    // 9-3-2 = 4
-    //
-    // >NZ_G49.1
-    // 0123456789
+	// >gi|1234|
+	// 0123456789
+	//
+	// 9-3-2 = 4
+	//
+	// >NZ_G49.1
+	// 0123456789
 
-    //std::cout << "found the indentifier : " << content << " in the header " ;
-    PhysicalKmerColor identifier=0;
+	//std::cout << "found the indentifier : " << content << " in the header " ;
+	PhysicalKmerColor identifier=0;
 
-    // maximum value for a uint64_t:
-    // 18446744073709551615
-    // xxxx000yyyyyyyyyyyyy
-    //    10000000000000000
-    // xxxx0000000000000000
-    //     000yyyyyyyyyyyyy
+	// maximum value for a uint64_t:
+	// 18446744073709551615
+	// xxxx000yyyyyyyyyyyyy
+	//	10000000000000000
+	// xxxx0000000000000000
+	//	 000yyyyyyyyyyyyy
 
-    //sdbm algorithm implementation http://www.cse.yorku.ca/~oz/hash.html
+	//sdbm algorithm implementation http://www.cse.yorku.ca/~oz/hash.html
 	for (string::const_iterator it = content.begin();it!=content.end();++it){
 		identifier = ((int) *it) + (identifier << 6)  + (identifier << 16) - identifier ;
 	}
 
-    //remove the fist 4 digit from the left for the namespace
-    identifier = identifier - ((identifier/COLOR_NAMESPACE_MULTIPLIER)*COLOR_NAMESPACE_MULTIPLIER);
-    return identifier;
+	//remove the fist 4 digit from the left for the namespace
+	identifier = identifier - ((identifier/COLOR_NAMESPACE_MULTIPLIER)*COLOR_NAMESPACE_MULTIPLIER);
+
+	return identifier;
 }
 
 bool SearchDirectory::hasDirectory(int file){
@@ -717,7 +720,7 @@ string SearchDirectory::filterName(string a){
 /* 
  * >EMBL_CDS:CBW26015 CBW26015.1 */
 bool SearchDirectory::hasIdentifier_EMBL_CDS(){
-	
+
 	string currentSequenceHeader=m_currentSequenceHeader;
 
 	if(currentSequenceHeader.find(">EMBL_CDS:") == 0){

--- a/code/Searcher/SearchDirectory.cpp
+++ b/code/Searcher/SearchDirectory.cpp
@@ -123,7 +123,7 @@ void SearchDirectory::countEntriesInFile(int fileNumber){
 	#endif
 
 	char line[10000];
-	
+
 	if(!f){
 		cout<<"Error, cannot open "<<file.str()<<endl;
 		f.close();
@@ -152,7 +152,7 @@ int SearchDirectory::getSize(){
 }
 
 void SearchDirectory::setCount(int file,int count){
-	
+
 	#ifdef CONFIG_ASSERT
 	int current=m_counts[file];
 	if(current!=0){
@@ -209,7 +209,7 @@ void SearchDirectory::createSequenceReader(int file,int sequence,int kmerLength)
 
 		m_currentFileStream=fopen(fileName.str().c_str(),"r");
 		m_currentFile=file;
-	
+
 		// we set it to -1 to be able to pick up 0
 		m_currentSequence=-1;// start at the beginning
 
@@ -304,7 +304,7 @@ void SearchDirectory::readLineFromFile(char*line,int length){
 
 		return;
 	}
-	
+
 	#ifdef CONFIG_ASSERT
 	assert(strlen(m_bufferedLine)==0);
 	assert(!m_hasBufferedLine);
@@ -320,7 +320,7 @@ void SearchDirectory::readLineFromFile(char*line,int length){
 	fgets(line,length,m_currentFileStream);
 
 	// remove the new line symbol, if any
-	
+
 	if(line[strlen(line)-1]=='\n'){
 		line[strlen(line)-1]='\0';
 	}
@@ -530,12 +530,12 @@ void SearchDirectory::loadSomeSequence(){
 	char newContent[CONFIG_COLORED_LINE_MAX_LENGTH];
 	int contentPosition=0;
 	strcpy(newContent,"");
-	
+
 	// copy old content
-	// discard already processed content -- the bytes 
+	// discard already processed content -- the bytes
 	// before m_currentSequencePosition that is
 	//cout<<"code 203"<<endl;
-	
+
 	int theLength=strlen(m_currentSequenceBuffer);
 
 	while(m_currentSequencePosition<theLength){

--- a/code/Searcher/SearchDirectory.cpp
+++ b/code/Searcher/SearchDirectory.cpp
@@ -229,16 +229,16 @@ void SearchDirectory::createSequenceReader(int file,int sequence,int kmerLength)
 	if(m_currentSequence>=sequence){
 		cout<<"m_currentSequence: "<<m_currentSequence<<" sequence: "<<sequence<<endl;
 	}
-	
+
 	// be need to be at least before the one we want to 
 	// pick it up
 	assert(m_currentSequence < sequence);
 	#endif
 
 	// here we want to advance to the sequence 
-	
+
 	while(m_currentSequence<sequence && !feof(m_currentFileStream)){
-		
+
 		char line[CONFIG_COLORED_LINE_MAX_LENGTH];
 		strcpy(line,"");
 
@@ -626,59 +626,74 @@ bool SearchDirectory::hasCurrentSequenceIdentifier(){
 
 	string currentSequenceHeader=m_currentSequenceHeader;
 
-	//cout<<"Identifier= "<<m_currentSequenceHeader<<endl;
 
-	// this means that the sequences are not genome sequences
-	// but are genes or something like that.
-	//if(m_currentSequenceHeader.find("|:") != string::npos){
-		//cout<<"Contains '|:'"<<endl;
 
-		//return false;
-	//}
-
-	if(currentSequenceHeader.find(">gi|") == string::npos)
+	if(currentSequenceHeader.find(">") == string::npos)
 		return false;
 
-	if(currentSequenceHeader.find(">gi|")==0)
+	if(currentSequenceHeader.find(">")==0)
 		return true;
 
 	return false;
 }
 
 PhysicalKmerColor SearchDirectory::getCurrentSequenceIdentifier(){
-	int count=0;
-	int i=0;
+    //int count=0;
+    int i=0;
+    string content;
+    string currentSequenceHeader=m_currentSequenceHeader;
+    //if the old NCBI files are used :
+    if (currentSequenceHeader.find(">gi|") != string::npos ) {
+        int count = 0;
+        int j = 0;
+        while (i < (int) currentSequenceHeader.length() && count < 4) {
+            if (currentSequenceHeader[i] == '|'){
+                count++;
+                if (count == 3) j = i;
+                }
+            i++;
+        }
+        if (count != 4)
+            return DUMMY_IDENTIFIER; // return a dummy identifier
+        content = currentSequenceHeader.substr(j + 1, i - j - 2);
+    }
+    //if the new NCBI files are used :
+    else {
+        while (i < (int) currentSequenceHeader.length() && currentSequenceHeader[i] != ' ') {
+            i++;
+        }
+        if(i==currentSequenceHeader.length())
+            return DUMMY_IDENTIFIER; // return a dummy identifier
+        content=currentSequenceHeader.substr(1,i-1);
+    }
 
-	string currentSequenceHeader=m_currentSequenceHeader;
 
-	while(i<(int)currentSequenceHeader.length() && count<2){
-		if(currentSequenceHeader[i]=='|')
-			count++;
-		
-		
-		i++;
+    // >gi|1234|
+    // 0123456789
+    //
+    // 9-3-2 = 4
+    //
+    // >NZ_G49.1
+    // 0123456789
+
+    //std::cout << "found the indentifier : " << content << " in the header " ;
+    PhysicalKmerColor identifier=0;
+
+    // maximum value for a uint64_t:
+    // 18446744073709551615
+    // xxxx000yyyyyyyyyyyyy
+    //    10000000000000000
+    // xxxx0000000000000000
+    //     000yyyyyyyyyyyyy
+
+    //sdbm algorithm implementation http://www.cse.yorku.ca/~oz/hash.html
+	for (string::const_iterator it = content.begin();it!=content.end();++it){
+		identifier = ((int) *it) + (identifier << 6)  + (identifier << 16) - identifier ;
 	}
 
-	if(count!=2){
-		return DUMMY_IDENTIFIER; // return a dummy identifier
-	}
-
-	// >gi|1234|
-	//
-	// 0123456789
-	//
-	// 9-4-1 = 4
-	//
-	string content=currentSequenceHeader.substr(4,i-4-1);
-
-	istringstream aStream;
-	aStream.str(content);
-
-	PhysicalKmerColor identifier;
-
-	aStream>>identifier;
-
-	return identifier;
+    //remove the fist 4 digit from the left for the namespace
+    identifier = identifier - ((identifier/COLOR_NAMESPACE_MULTIPLIER)*COLOR_NAMESPACE_MULTIPLIER);
+    return identifier;
 }
 
 bool SearchDirectory::hasDirectory(int file){

--- a/code/Searcher/SearchDirectory.h
+++ b/code/Searcher/SearchDirectory.h
@@ -26,7 +26,7 @@
 
 #include <code/KmerAcademyBuilder/Kmer.h>
 #include <code/GeneOntology/KeyEncoder.h>
-
+#include <code/Searcher/ColorSet.h>
 #include <set>
 #include <string>
 #include <fstream>

--- a/code/Searcher/Searcher.cpp
+++ b/code/Searcher/Searcher.cpp
@@ -249,7 +249,7 @@ void Searcher::call_RAY_MASTER_MODE_COUNT_SEARCH_ELEMENTS(){
 	}else if(m_sendCounts && m_ranksSynced == m_parameters->getSize()){
 		if(m_masterDirectoryIterator==m_searchDirectories_size){
 			m_sendCounts=false;
-			
+
 			m_switchMan->sendToAll(m_outbox,m_parameters->getRank(),RAY_MPI_TAG_SEARCH_MASTER_SHARING_DONE);
 		}else if(m_masterFileIterator==(int)m_searchDirectories[m_masterDirectoryIterator].getSize()){
 			m_masterDirectoryIterator++;
@@ -958,7 +958,7 @@ void Searcher::call_RAY_SLAVE_MODE_CONTIG_BIOLOGICAL_ABUNDANCES(){
 		buffer[bufferSize++]=lengthInKmers;
 		buffer[bufferSize++]=m_coloredKmers;
 		buffer[bufferSize++]=mode;
-		
+
 		double*bufferDouble=(double*)(buffer+bufferSize++);
 		bufferDouble[0]=mean;
 
@@ -2031,7 +2031,7 @@ void Searcher::call_RAY_SLAVE_MODE_SEQUENCE_BIOLOGICAL_ABUNDANCES(){
 	
 				// don't dump too many of these distribution
 				// otherwise, it may result in too many files
-	
+
 				dumpDistributions();
 			}
 
@@ -2248,7 +2248,7 @@ void Searcher::call_RAY_SLAVE_MODE_SEQUENCE_BIOLOGICAL_ABUNDANCES(){
 				kmer.unpack(buffer,&bufferPosition);
 
 				int sequencePosition=buffer[bufferPosition++];
-	
+
 				#ifdef CONFIG_CONTIG_IDENTITY_VERBOSE
 				cout<<"sequence position "<<sequencePosition<<endl;
 				#endif
@@ -2294,7 +2294,7 @@ void Searcher::call_RAY_SLAVE_MODE_SEQUENCE_BIOLOGICAL_ABUNDANCES(){
 					bufferPosition++; // skip th total
 
 					if(numberOfPaths>0 && nicelyAssembled && colorsAreUniqueInNamespaces){
-						
+
 						m_coloredAssembledCoverageDistribution[coverage]++;
 						m_coloredAssembledMatches++;
 
@@ -2304,7 +2304,7 @@ void Searcher::call_RAY_SLAVE_MODE_SEQUENCE_BIOLOGICAL_ABUNDANCES(){
 					#ifdef CONFIG_CONTIG_IDENTITY_VERBOSE
 					cout<<"Paths: "<<numberOfPaths<<" total: "<<total<<endl;
 					#endif
-	
+
 					//bool reply=false;
 
 					// this flag will say if we need to send another message
@@ -2322,14 +2322,14 @@ void Searcher::call_RAY_SLAVE_MODE_SEQUENCE_BIOLOGICAL_ABUNDANCES(){
 						#endif
 
 						// don't process the same item twice for the current position
-						if(m_observedPaths.count(sequencePosition)>0 
+						if(m_observedPaths.count(sequencePosition)>0
 							&& m_observedPaths[sequencePosition].count(contigPath)>0){  // a contig path can only be processed once per position<
 
 							#ifdef CONFIG_CONTIG_IDENTITY_VERBOSE
 							cout<<"Skipping because we already used "<<contigPath<<" for position "<<sequencePosition<<endl;
 							#endif
 
-							continue; // 
+							continue; //
 						}
 
 						// a contig position can only be utilised once
@@ -2360,7 +2360,7 @@ void Searcher::call_RAY_SLAVE_MODE_SEQUENCE_BIOLOGICAL_ABUNDANCES(){
 
 						// mark it as utilised for the current sequence position
 						m_observedPaths[sequencePosition].insert(contigPath);
-	
+
 						// we don't care if the vertex is repeated
 						// for now.
 					}
@@ -2439,7 +2439,7 @@ void Searcher::createTrees(){
 	if(m_parameters->getRank()==MASTER_RANK){
 		ostringstream directory6;
 		directory6<<m_parameters->getPrefix()<<"/BiologicalAbundances/_Directories.tsv";
-	
+
 		directoriesFile.open(directory6.str().c_str(),ios_base::app);
 		directoriesFile<<"#Directory	DirectoryName	Files"<<endl;
 	}
@@ -2515,7 +2515,7 @@ void Searcher::createTrees(){
 }
 
 string Searcher::getFileBaseName(int i,int j){
-			
+
 	string*file=m_searchDirectories[i].getFileName(j);
 
 	int theLength=file->length();
@@ -2641,7 +2641,7 @@ void Searcher::showProcessedKmers(){
 	}
 
 	if(m_directoryIterator < m_searchDirectories_size &&
-  		m_fileIterator < m_searchDirectories[m_directoryIterator].getSize()
+		m_fileIterator < m_searchDirectories[m_directoryIterator].getSize()
 		&& m_sequenceIterator < m_searchDirectories[m_directoryIterator].getCount(m_fileIterator)){
 
 		cout<<"Rank "<<m_parameters->getRank()<<" biological abundances ";
@@ -2651,11 +2651,13 @@ void Searcher::showProcessedKmers(){
 		cout<<"/"<<m_searchDirectories[m_directoryIterator].getCount(m_fileIterator)<<"]"<<endl;
 	}
 
+	#ifdef CONFIG_DEBUG_COLORS
 	cout<<"Rank "<<m_parameters->getRank()<<" "<<SLAVE_MODES[m_switchMan->getSlaveMode()]<<" processed files: "<<m_processedFiles<<"/"<<m_filesToProcess<<endl;
 	cout<<"Rank "<<m_parameters->getRank()<<" "<<SLAVE_MODES[m_switchMan->getSlaveMode()]<<" processed sequences in file: "<<m_sequenceIterator<<"/"<<m_sequencesToProcessInFile<<endl;
 	cout<<"Rank "<<m_parameters->getRank()<<" "<<SLAVE_MODES[m_switchMan->getSlaveMode()]<<" total processed sequences: "<<m_processedSequences-1<<"/"<<m_sequencesToProcess<<endl;
 	cout<<"Rank "<<m_parameters->getRank()<<" "<<SLAVE_MODES[m_switchMan->getSlaveMode()]<<" processed k-mers for current sequence: "<<m_numberOfKmers<<"/"<<m_currentLength<<endl;
 	cout<<"Rank "<<m_parameters->getRank()<<" "<<SLAVE_MODES[m_switchMan->getSlaveMode()]<<" total processed k-mers: "<<m_kmersProcessed<<endl;
+	#endif
 
 	m_derivative.addX(m_kmersProcessed);
 
@@ -2663,12 +2665,9 @@ void Searcher::showProcessedKmers(){
 	m_derivative.printStatus(SLAVE_MODES[m_switchMan->getSlaveMode()],
 			m_switchMan->getSlaveMode());
 
-	if(m_switchMan->getSlaveMode()==RAY_SLAVE_MODE_ADD_COLORS){
-		
-
-		m_colorSet.printSummary(&cout,false);
-		//m_colorSet.printColors();
-	}
+	// if(m_switchMan->getSlaveMode()==RAY_SLAVE_MODE_ADD_COLORS){
+	// 	m_colorSet.printSummary(&cout,false);
+	// }
 
 	m_lastPrinted=m_kmersProcessed;
 
@@ -2746,7 +2745,7 @@ void Searcher::call_RAY_MPI_TAG_GET_COVERAGE_AND_PATHS(Message*message){
 
 		if(node!=NULL){
 			coverage=node->getCoverage(&vertex);
-			
+
 			#ifdef CONFIG_CONTIG_IDENTITY_VERBOSE
 			cout<<"Not NULL, coverage= "<<coverage<<endl;
 			#endif
@@ -2866,7 +2865,7 @@ void Searcher::call_RAY_MPI_TAG_GET_COVERAGE_AND_PATHS(Message*message){
 				message2[outputBufferPosition++]=strand;
 
 				processed++;
-				
+
 				pathIndex++;
 
 				// we just don't send them all because
@@ -2875,7 +2874,7 @@ void Searcher::call_RAY_MPI_TAG_GET_COVERAGE_AND_PATHS(Message*message){
 					break;
 
 			}
-	
+
 			message2[positionForCount]=processed;
 			message2[positionForIndex]=pathIndex;
 			message2[positionForTotal]=paths.size();
@@ -2897,7 +2896,7 @@ void Searcher::call_RAY_MPI_TAG_GET_COVERAGE_AND_PATHS(Message*message){
 
 void Searcher::call_RAY_MPI_TAG_ADD_KMER_COLOR(Message*message){
 	// add the color
-	
+
 	#ifdef CONFIG_DEBUG_COLORS
 	cout<<"Sending reply to "<<message->getSource()<<" slaveMode= "<<SLAVE_MODES[m_switchMan->getSlaveMode()]<<endl;
 	#endif
@@ -2964,7 +2963,7 @@ void Searcher::addColorToKmer(Vertex*node,PhysicalKmerColor color){
 
 	// maybe this color was purged..
 	//assert(m_colorSet.getNumberOfPhysicalColors(virtualColorHandle)+1 == m_colorSet.getNumberOfPhysicalColors(newVirtualColor));
-	
+
 	assert(m_colorSet.getNumberOfReferences(newVirtualColor)>=1);
 	assert(m_colorSet.getNumberOfReferences(virtualColorHandle)>=0);
 	#endif
@@ -3118,8 +3117,8 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 		#endif
 
 	// all directories were processed
-	}else if(m_directoryIterator==m_searchDirectories_size && !m_locallyFinishedColoring){
-	
+	} else if(m_directoryIterator==m_searchDirectories_size && !m_locallyFinishedColoring){
+
 		showProcessedKmers();
 
 		m_bufferedData.showStatistics(m_parameters->getRank());
@@ -3182,7 +3181,7 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 
 	// all files in a directory were processed
 	}else if(m_fileIterator==(int)m_searchDirectories[m_directoryIterator].getSize()){
-	
+
 		cout<<"Rank "<<m_parameters->getRank()<<" has colored its entries from "<<m_directoryNames[m_directoryIterator]<<endl;
 		cout<<endl;
 
@@ -3196,7 +3195,7 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 	}else if(!isFileOwner(m_globalFileIterator)){
 
 		m_globalSequenceIterator+=m_searchDirectories[m_directoryIterator].getCount(m_fileIterator);
-		
+
 		showProcessedKmers();
 
 		// skip the file
@@ -3219,8 +3218,8 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 
 		// we processed all the k-mers
 		// now we need to flush the remaining half-full buffers
-		// this section is now used if 
-		// force=true 
+		// this section is now used if
+		// force=true
 		// in the above code
 		}else if(!m_bufferedData.isEmpty()){
 
@@ -3256,7 +3255,7 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 	// start a sequence
 	}else if(!m_createdSequenceReader){
 		// initiate the reader I guess
-	
+
 		#ifdef CONFIG_DEBUG_COLORS
 		cout<<"Creating sequence reader."<<endl;
 		#endif
@@ -3268,7 +3267,7 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 		m_numberOfKmers=0;
 		m_createdSequenceReader=true;
 
-		// check if we need to color the graph 
+		// check if we need to color the graph
 		// for this sequence...
 
 		m_mustAddColors=true;
@@ -3325,7 +3324,7 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 
 		// the current sequence has been processed
 		if( !m_searchDirectories[m_directoryIterator].hasNextKmer(m_kmerLength)){
-			
+
 
 			#ifdef CONFIG_ASSERT
 			assert(m_directoryIterator<m_searchDirectories_size);
@@ -3344,7 +3343,7 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 		// pull data from the sequence
 		// and throw messages onto the network
 		}else if(m_pendingMessages==0 ){
-	
+
 			bool force=CONFIG_FORCE_VALUE_FOR_MAXIMUM_SPEED;
 
 			// pull k-mers from the sequence and fill buffers
@@ -3530,7 +3529,7 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 		m_arrayOfFiles_Buffer[directoryIterator]=new ostringstream;
 
 		// create tsv file too
-	
+
 		ostringstream fileName_tsv;
 		fileName_tsv<<m_parameters->getPrefix()<<"/BiologicalAbundances/";
 		fileName_tsv<<"0.Profile."<<baseName<<".tsv";
@@ -3546,14 +3545,14 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 		m_activeFiles++;
 
 		#ifdef CONFIG_ASSERT
-		assert(m_activeFiles>=1); 
+		assert(m_activeFiles>=1);
 		#endif
 
 		ostringstream content88;
 		content88<<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"<<endl;
 
 		content88<<"<root><sample>"<<m_parameters->getSampleName()<<"</sample><searchDirectory>"<<baseName<<"</searchDirectory>"<<endl;
-	
+
 		content88<<"<totalAssembledKmerObservations>"<<m_totalNumberOfAssembledKmerObservations;
 		content88<<"</totalAssembledKmerObservations>"<<endl;
 		content88<<"<totalAssembledKmers>"<<m_totalNumberOfAssembledKmers;
@@ -3571,7 +3570,7 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 		content88<<"</totalAssembledColoredKmerObservations>"<<endl;
 		content88<<"<totalAssembledColoredKmers>"<<m_totalNumberOfAssembledColoredKmers;
 		content88<<"</totalAssembledColoredKmers>"<<endl;
-		
+
 
 
 
@@ -3852,7 +3851,7 @@ void Searcher::flushSequenceAbundanceXMLBuffer(int directoryIterator,bool force)
 	assert(m_arrayOfFiles_Buffer.count(directoryIterator)>0);
 	assert(m_arrayOfFiles.count(directoryIterator)>0);
 	#endif
-	
+
 	if(flushFileOperationBuffer_FILE(force,(m_arrayOfFiles_Buffer[directoryIterator]),
 		m_arrayOfFiles[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE)){
 
@@ -3869,7 +3868,7 @@ void Searcher::flushContigIdentificationBuffer(int directoryIterator,bool force)
 	assert(m_identificationFiles.count(directoryIterator)>0);
 	assert(m_identificationFiles_Buffer.count(directoryIterator)>0);
 	#endif
-	
+
 	if(flushFileOperationBuffer_FILE(force,(m_identificationFiles_Buffer[directoryIterator]),
 		m_identificationFiles[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE)){
 
@@ -3915,7 +3914,7 @@ void Searcher::call_RAY_MPI_TAG_VIRTUAL_COLOR_DATA(Message*message){
  * The positions from position up to count-1 are the actual
  * physical colors.
  */
-	
+
 
 		#ifdef CONFIG_COLORED_GRAPH_DEBUG
 		cout<<"[call_RAY_MPI_TAG_VIRTUAL_COLOR_DATA] source: "<<source;
@@ -3924,7 +3923,7 @@ void Searcher::call_RAY_MPI_TAG_VIRTUAL_COLOR_DATA(Message*message){
 		#endif /* CONFIG_COLORED_GRAPH_DEBUG */
 
 		set<PhysicalKmerColor> coloredBits;
-	
+
 		for(int i=0;i<physicalColors;i++){
 			PhysicalKmerColor color=buffer[position+i];
 
@@ -3936,7 +3935,7 @@ void Searcher::call_RAY_MPI_TAG_VIRTUAL_COLOR_DATA(Message*message){
 
 			coloredBits.insert(color);
 		}
-	
+
 		VirtualKmerColorHandle globalColor=m_masterColorSet.findVirtualColor(&coloredBits);
 
 		for(uint64_t i=0;i<references;i++){
@@ -4076,7 +4075,7 @@ void Searcher::generateSummaryOfColoredDeBruijnGraph(){
 			f1<<"<physicalColors>";
 			for(set<PhysicalKmerColor>::iterator j=i->second.begin();
 				j!=i->second.end();++j){
-	
+
 				PhysicalKmerColor color=*j;
 				f1<<" "<<color;
 			}
@@ -4096,15 +4095,12 @@ void Searcher::generateSummaryOfColoredDeBruijnGraph(){
 }
 
 void Searcher::call_RAY_MPI_TAG_VIRTUAL_COLOR_DATA_REPLY(Message*message){
-
 	m_messageReceived=true;
 }
 
 void Searcher::flushCoverageXMLBuffer(bool force){
-	
 	if(flushFileOperationBuffer(force,&m_currentCoverageFile_Buffer,
 		&m_currentCoverageFile,CONFIG_FILE_IO_BUFFER_SIZE)){
-		
 		m_coverageXMLflushOperations++;
 	}
 }

--- a/code/Searcher/Searcher.cpp
+++ b/code/Searcher/Searcher.cpp
@@ -111,7 +111,7 @@ GridTable*graph){
 
 	m_countElementsSlaveStarted=false;
 	m_countElementsMasterStarted=false;
-	
+
 	m_countContigKmersMasterStarted=false;
 	m_countContigKmersSlaveStarted=false;
 
@@ -229,7 +229,7 @@ void Searcher::call_RAY_MASTER_MODE_COUNT_SEARCH_ELEMENTS(){
 
 	}else if(m_ranksDoneCounting==m_parameters->getSize()){
 		m_ranksDoneCounting=-1;
-		
+
 		#ifdef CONFIG_ASSERT
 		assert(m_parameters->getRank() == 0);
 		#endif
@@ -295,8 +295,6 @@ void Searcher::call_RAY_SLAVE_MODE_COUNT_SEARCH_ELEMENTS(){
 		#endif
 
 
-	
-
 	// the counting is completed.
 	}else if(m_inbox->hasMessage(RAY_MPI_TAG_SEARCH_MASTER_SHARING_DONE)){
 		m_switchMan->closeSlaveModeLocally(m_outbox,m_parameters->getRank());
@@ -327,7 +325,7 @@ void Searcher::call_RAY_SLAVE_MODE_COUNT_SEARCH_ELEMENTS(){
 		// because default copy constructors
 		// don't manage ifstream attributes correctly
 		// which results in a compilation error
-	
+
 		if(directories->size() > 0){
 			m_searchDirectories_size=directories->size();
 
@@ -356,7 +354,7 @@ void Searcher::call_RAY_SLAVE_MODE_COUNT_SEARCH_ELEMENTS(){
 		}
 
 		m_listedDirectories=true;
-		
+
 		m_countedDirectories=false;
 	}else if(!m_countedDirectories){
 
@@ -402,7 +400,7 @@ void Searcher::call_RAY_SLAVE_MODE_COUNT_SEARCH_ELEMENTS(){
 		m_fileIterator=0;
 		m_globalFileIterator=0;
 		m_waiting=false;
-	
+
 		#ifdef CONFIG_COUNT_ELEMENTS_VERBOSE
 		cout<<"Received RAY_MPI_TAG_SEARCH_SHARE_COUNTS"<<endl;
 		#endif
@@ -422,7 +420,7 @@ void Searcher::call_RAY_SLAVE_MODE_COUNT_SEARCH_ELEMENTS(){
 			cout<<"Synchronized counts."<<endl;
 			#endif
 
-		}else if(!m_waiting 
+		}else if(!m_waiting
 			&& m_fileIterator==(int)m_searchDirectories[m_directoryIterator].getSize()){
 
 			cout<<"Rank "<<m_parameters->getRank()<<" synced "<<*(m_searchDirectories[m_directoryIterator].getDirectoryName())<<endl;
@@ -440,12 +438,12 @@ void Searcher::call_RAY_SLAVE_MODE_COUNT_SEARCH_ELEMENTS(){
 
 		/* otherwise we still have things to send */
 		}else if(!m_waiting){
-			
+
 			int count=m_searchDirectories[m_directoryIterator].getCount(m_fileIterator);
 
 			// we don't need to sync stuff with 0 sequences
 			// because 0 is the default value
-			
+
 			// only sync if we are the owner.
 			if(!isFileOwner(m_globalFileIterator) || count == 0){
 
@@ -472,7 +470,6 @@ void Searcher::call_RAY_SLAVE_MODE_COUNT_SEARCH_ELEMENTS(){
 
 			m_waiting=true;
 
-		
 			#ifdef CONFIG_COUNT_ELEMENTS_VERBOSE
 			cout<<"Rank "<<m_parameters->getRank()<<" Sending RAY_MPI_TAG_SEARCH_ELEMENTS directory="<<m_directoryIterator<<" file="<<m_fileIterator<<" objects="<<count<<" globalHandle="<<m_fileIterator<<endl;
 			#endif
@@ -515,7 +512,7 @@ void Searcher::countKmerObservations(LargeCount*localAssembledKmerObservations,
 
 		Vertex*node=iterator.next();
 		Kmer key=*(iterator.getKey());
-		
+
 		if(parity==0){
 			parity=1;
 		}else if(parity==1){
@@ -545,7 +542,7 @@ void Searcher::countKmerObservations(LargeCount*localAssembledKmerObservations,
 		bool assembled=nicelyAssembled;
 
 		// at this point, we have a nicely assembled k-mer
-		
+
 		CoverageDepth kmerCoverage=node->getCoverage(&key);
 
 		(*totalKmers)++;
@@ -2021,14 +2018,14 @@ void Searcher::call_RAY_SLAVE_MODE_SEQUENCE_BIOLOGICAL_ABUNDANCES(){
 				#endif
 
 				m_pendingMessages++;
-				
+
 				#ifdef CONFIG_ASSERT
 				assert(m_pendingMessages==1);
 				#endif
 
 				/* also dump the distribution */
 				/* write it in BiologicalAbundances/Directory/FileName/SequenceNumber.tsv */
-	
+
 				// don't dump too many of these distribution
 				// otherwise, it may result in too many files
 
@@ -2764,7 +2761,7 @@ void Searcher::call_RAY_MPI_TAG_GET_COVERAGE_AND_PATHS(Message*message){
 			set<PhysicalKmerColor>*physicalColors=m_colorSet.getPhysicalColors(color);
 
 			// verify that there is only one color in each namespace
-			
+
 			uniqueness=true;
 
 			map<int,int> counts;
@@ -2772,9 +2769,9 @@ void Searcher::call_RAY_MPI_TAG_GET_COVERAGE_AND_PATHS(Message*message){
 			for(set<PhysicalKmerColor>::iterator j=physicalColors->begin();
 				j!=physicalColors->end();j++){
 				PhysicalKmerColor physicalColor=*j;
-		
+
 				int nameSpace=getNamespace(physicalColor);
-			
+
 				counts[nameSpace]++;
 				if(counts[nameSpace]>1){
 					uniqueness=false;
@@ -2803,7 +2800,7 @@ void Searcher::call_RAY_MPI_TAG_GET_COVERAGE_AND_PATHS(Message*message){
 
 		if(node!=NULL){
 			Kmer lowerKey=node->getKey();
-			
+
 			bool weHaveLowerKey=lowerKey.isEqual(&vertex);
 
 			vector<Direction> paths;
@@ -3437,7 +3434,7 @@ void Searcher::call_RAY_SLAVE_MODE_ADD_COLORS(){
 			}
 
 		}
-	
+
 	}
 
 }
@@ -3475,7 +3472,7 @@ int Searcher::getDistributionMode(map<CoverageDepth,LargeCount>*distribution){
 void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 
 	// unpack stuff
-	
+
 	int bufferPosition=0;
 	MessageUnit*buffer=message->getBuffer();
 
@@ -3516,7 +3513,7 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 	// open the file
 	// don't open it if there are 0 matches
 	if(entryIsWorthy && m_arrayOfFiles.count(directoryIterator)==0) {
-		
+
 		string baseName=getDirectoryBaseName(directoryIterator);
 
 		ostringstream fileName;
@@ -3586,14 +3583,14 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 	if(entryIsWorthy ){
 
 		ostringstream content;
-		
+
 		string sequenceName=sequenceNameFromMessage;
 
 		double ratio=(0.0+matches)/numberOfKmers;
 
 		ostringstream header;
 		header<<"#Category	Sequence number	Sequence name	K-mer length	Length in k-mers";
-		
+
 		header<<"	K-mer matches	Ratio	Mode k-mer coverage depth";
 
 		header<<"	Uniquely colored k-mer matches";
@@ -3609,7 +3606,7 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 
 		header<<endl;
 
-		
+
 		content<<"<entry>"<<endl;
 
 		content<<"<namespace>"<<directoryIterator<<"</namespace>";
@@ -3619,7 +3616,7 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 		content<<"<file>"<<m_fileNames[directoryIterator][fileIterator]<<"</file>"<<endl;
 		content<<"<sequence>"<<sequenceIterator<<"</sequence><name>"<<sequenceName<<"</name>"<<endl;
 		content<<"<kmerLength>"<<m_parameters->getWordSize();
-		
+
 		content<<"</kmerLength><lengthInKmers>"<<numberOfKmers<<"</lengthInKmers>"<<endl;
 
 		content<<"<raw><kmerMatches>"<<matches<<"</kmerMatches><proportion>"<<ratio<<"</proportion><modeKmerCoverage>";
@@ -3639,7 +3636,7 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 		if(numberOfKmers!=0){
 			assembledRatio/=numberOfKmers;
 		}
-		
+
 		content<<"<assembled><kmerMatches>"<<assembledMatches;
 		content<<"</kmerMatches><proportion>"<<assembledRatio<<"</proportion>";
 		content<<"<modeKmerCoverage>"<<assembledMode<<"</modeKmerCoverage>";
@@ -3721,115 +3718,115 @@ void Searcher::call_RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_ENTRY(Message*message){
 
 void Searcher::call_RAY_MPI_TAG_CONTIG_IDENTIFICATION(Message*message){
 
-       	MessageUnit*messageBuffer=message->getBuffer();
+	MessageUnit*messageBuffer=message->getBuffer();
 
-       	// process the message
-       	int bufferPosition=0;
-       	PathHandle contig=messageBuffer[bufferPosition++];
+	// process the message
+	int bufferPosition=0;
+	PathHandle contig=messageBuffer[bufferPosition++];
 
-       	char strand=messageBuffer[bufferPosition++];
+	char strand=messageBuffer[bufferPosition++];
 
 	#ifdef CONFIG_ASSERT
 	assert(m_contigLengths.count(contig)>0);
-       	#endif
+	#endif
 
-       	int kmerLength=m_parameters->getWordSize();
-       	int contigLength=m_contigLengths[contig];
-       	int count=messageBuffer[bufferPosition++];
+	int kmerLength=m_parameters->getWordSize();
+	int contigLength=m_contigLengths[contig];
+	int count=messageBuffer[bufferPosition++];
 
-	#ifdef CONFIG_ASSERT
-       	assert(kmerLength>0);
-       	assert(contigLength>0);
-       	assert(count>0);
-       	#endif
+#ifdef CONFIG_ASSERT
+	assert(kmerLength>0);
+	assert(contigLength>0);
+	assert(count>0);
+#endif
 
-       	int directoryIterator=messageBuffer[bufferPosition++];
-       	int fileIterator=messageBuffer[bufferPosition++];
+	int directoryIterator=messageBuffer[bufferPosition++];
+	int fileIterator=messageBuffer[bufferPosition++];
 
-       	#ifdef CONFIG_ASSERT
-       	assert(directoryIterator<m_searchDirectories_size);
-       	assert(fileIterator<m_searchDirectories[directoryIterator].getSize());
-       	#endif
+#ifdef CONFIG_ASSERT
+	assert(directoryIterator<m_searchDirectories_size);
+	assert(fileIterator<m_searchDirectories[directoryIterator].getSize());
+#endif
 
-       	string category=m_fileNames[directoryIterator][fileIterator];
+	string category=m_fileNames[directoryIterator][fileIterator];
 
 	int sequenceIterator=messageBuffer[bufferPosition++];
 
-       	int numberOfKmers=messageBuffer[bufferPosition++];
+	int numberOfKmers=messageBuffer[bufferPosition++];
 
-       	// the number of matches can not be greater than
-       	// the number of k-mers in the query sequence
-       	// otherwise, it does not make sense
-       	#ifdef CONFIG_ASSERT
-       	if(count> numberOfKmers){
-       		cout<<"Error: "<<count<<" k-mers observed, but the contig has only "<<numberOfKmers<<endl;
-       		cout<<"Sequence= "<<sequenceIterator<<endl;
-       	}
-       	assert(count <= numberOfKmers);
-       	#endif
+	// the number of matches can not be greater than
+	// the number of k-mers in the query sequence
+	// otherwise, it does not make sense
+#ifdef CONFIG_ASSERT
+	if(count> numberOfKmers){
+		cout<<"Error: "<<count<<" k-mers observed, but the contig has only "<<numberOfKmers<<endl;
+		cout<<"Sequence= "<<sequenceIterator<<endl;
+	}
+	assert(count <= numberOfKmers);
+#endif
 
-       	char*sequenceName=(char*) (messageBuffer+bufferPosition);
+	char*sequenceName=(char*) (messageBuffer+bufferPosition);
 
-       	// contigLength can not be 0 anyway
-       	double ratio=(0.0+count)/contigLength;
+	// contigLength can not be 0 anyway
+	double ratio=(0.0+count)/contigLength;
 
-       	double sequenceRatio=count;
+	double sequenceRatio=count;
 
-       	if(numberOfKmers!=0)
-       		sequenceRatio/=numberOfKmers;
+	if(numberOfKmers!=0)
+		sequenceRatio/=numberOfKmers;
 
-       	bool thresholdIsGood=false;
+	bool thresholdIsGood=false;
 
-       	if(ratio >= CONFIG_SEARCH_THRESHOLD)
-       		thresholdIsGood=true;
+	if(ratio >= CONFIG_SEARCH_THRESHOLD)
+		thresholdIsGood=true;
 
-       	if(sequenceRatio >= CONFIG_SEARCH_THRESHOLD)
-       		thresholdIsGood=true;
+	if(sequenceRatio >= CONFIG_SEARCH_THRESHOLD)
+		thresholdIsGood=true;
 
-       	// open the file for reading
-       	if(thresholdIsGood &&
-       		count>0 && ( m_identificationFiles.count(directoryIterator)==0)){
+	// open the file for reading
+	if(thresholdIsGood &&
+	   count>0 && ( m_identificationFiles.count(directoryIterator)==0)){
 
-       		// create an empty file for identifications
-       		ostringstream identifications;
+		// create an empty file for identifications
+		ostringstream identifications;
 
-       		string*theDirectoryPath=m_searchDirectories[directoryIterator].getDirectoryName();
-       		string baseName=getBaseName(*theDirectoryPath);
-       		identifications<<m_parameters->getPrefix()<<"/BiologicalAbundances/";
-       		identifications<<baseName<<"/ContigIdentifications.tsv";
+		string*theDirectoryPath=m_searchDirectories[directoryIterator].getDirectoryName();
+		string baseName=getBaseName(*theDirectoryPath);
+		identifications<<m_parameters->getPrefix()<<"/BiologicalAbundances/";
+		identifications<<baseName<<"/ContigIdentifications.tsv";
 
-       		m_identificationFiles[directoryIterator]=fopen(identifications.str().c_str(),"a");
+		m_identificationFiles[directoryIterator]=fopen(identifications.str().c_str(),"a");
 		m_identificationFiles_Buffer[directoryIterator]=new ostringstream;
 
-       		ostringstream line;
-       	
-       		// push header
-       		line<<"#Contig name	K-mer length	Contig length in k-mers	Contig strand	Category	";
-       		line<<"Sequence number	Sequence name";
-       		line<<"	Sequence length in k-mers	Matches in contig	Contig length ratio";
-       		line<<"	Sequence length ratio"<<endl;
+		ostringstream line;
 
-       		*(m_identificationFiles_Buffer[directoryIterator])<<line.str();
+		// push header
+		line<<"#Contig name	K-mer length	Contig length in k-mers	Contig strand	Category	";
+		line<<"Sequence number	Sequence name";
+		line<<"	Sequence length in k-mers	Matches in contig	Contig length ratio";
+		line<<"	Sequence length ratio"<<endl;
+
+		*(m_identificationFiles_Buffer[directoryIterator])<<line.str();
 
 		flushContigIdentificationBuffer(directoryIterator,false);
-       	}
+	}
 
-       	// write an entry in the file
-       
-       	if(thresholdIsGood){
-       		ostringstream line;
-       		line<<"contig-"<<contig<<"	"<<kmerLength<<"	"<<contigLength;
-       		line<<"	"<<strand;
-       		line<<"	"<<category;
-       		line<<"	"<<sequenceIterator<<"	"<<sequenceName<<"	";
-       		line<<numberOfKmers<<"	"<<count<<"	"<<ratio<<"	"<<sequenceRatio<<endl;
+	// write an entry in the file
 
-       		*(m_identificationFiles_Buffer[directoryIterator])<<line.str();
-       	}
+	if(thresholdIsGood){
+		ostringstream line;
+		line<<"contig-"<<contig<<"	"<<kmerLength<<"	"<<contigLength;
+		line<<"	"<<strand;
+		line<<"	"<<category;
+		line<<"	"<<sequenceIterator<<"	"<<sequenceName<<"	";
+		line<<numberOfKmers<<"	"<<count<<"	"<<ratio<<"	"<<sequenceRatio<<endl;
+
+		*(m_identificationFiles_Buffer[directoryIterator])<<line.str();
+	}
 
 	// send a reply
 	m_switchMan->sendEmptyMessage(m_outbox,m_parameters->getRank(),
-		message->getSource(),RAY_MPI_TAG_CONTIG_IDENTIFICATION_REPLY);
+								  message->getSource(),RAY_MPI_TAG_CONTIG_IDENTIFICATION_REPLY);
 }
 
 string Searcher::getDirectoryBaseName(int directoryIterator){
@@ -3847,30 +3844,30 @@ LargeCount Searcher::getTotalNumberOfKmerObservations(){
 void Searcher::flushSequenceAbundanceXMLBuffer(int directoryIterator,bool force){
 
 
-	#ifdef CONFIG_ASSERT
+#ifdef CONFIG_ASSERT
 	assert(m_arrayOfFiles_Buffer.count(directoryIterator)>0);
 	assert(m_arrayOfFiles.count(directoryIterator)>0);
-	#endif
+#endif
 
 	if(flushFileOperationBuffer_FILE(force,(m_arrayOfFiles_Buffer[directoryIterator]),
-		m_arrayOfFiles[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE)){
+									 m_arrayOfFiles[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE)){
 
 		m_sequenceXMLflushOperations++;
 	}
 
 	flushFileOperationBuffer_FILE(force,m_arrayOfFiles_tsv_Buffer[directoryIterator],
-		m_arrayOfFiles_tsv[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE);
+								  m_arrayOfFiles_tsv[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE);
 }
 
 void Searcher::flushContigIdentificationBuffer(int directoryIterator,bool force){
 
-	#ifdef CONFIG_ASSERT
+#ifdef CONFIG_ASSERT
 	assert(m_identificationFiles.count(directoryIterator)>0);
 	assert(m_identificationFiles_Buffer.count(directoryIterator)>0);
-	#endif
+#endif
 
 	if(flushFileOperationBuffer_FILE(force,(m_identificationFiles_Buffer[directoryIterator]),
-		m_identificationFiles[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE)){
+									 m_identificationFiles[directoryIterator],CONFIG_FILE_IO_BUFFER_SIZE)){
 
 		m_contigIdentificationflushOperations++;
 	}
@@ -3879,9 +3876,9 @@ void Searcher::flushContigIdentificationBuffer(int directoryIterator,bool force)
 
 void Searcher::call_RAY_MPI_TAG_VIRTUAL_COLOR_DATA(Message*message){
 
-	#ifdef DEBUG_GRAPH_BROWSING
+#ifdef DEBUG_GRAPH_BROWSING
 	cout<<"server-side [call_RAY_MPI_TAG_VIRTUAL_COLOR_DATA] debug."<<endl;
-	#endif /* DEBUG_GRAPH_BROWSING */
+#endif /* DEBUG_GRAPH_BROWSING */
 
 	MessageUnit*buffer=(MessageUnit*)message->getBuffer();
 
@@ -4029,7 +4026,7 @@ void Searcher::generateSummaryOfColoredDeBruijnGraph(){
 		f1<<"<handle>";
 		f1<<currentVirtualColor<<endl;
 		f1<<"</handle>";
-	
+
 		f1<<"<references>";
 
 /*
@@ -4039,7 +4036,7 @@ void Searcher::generateSummaryOfColoredDeBruijnGraph(){
 		LargeCount numberOfKmers=references;
 		f1<<numberOfKmers;
 		f1<<"</references>"<<endl;
-	
+
 		f1<<"<ratio>"<<numberOfKmers/(m_totalKmers+0.0)<<"</ratio>";
 
 		map<int,set<PhysicalKmerColor> > classifiedData;
@@ -4221,7 +4218,7 @@ void Searcher::registerPlugin(ComputeCore*core){
 
 	RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_REPLY=core->allocateMessageTagHandle(plugin);
 	core->setMessageTagSymbol(plugin,RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_REPLY,"RAY_MPI_TAG_WRITE_SEQUENCE_ABUNDANCE_REPLY");
-	
+
 	RAY_MPI_TAG_GRAPH_COUNTS=core->allocateMessageTagHandle(plugin);
 	core->setMessageTagSymbol(plugin,RAY_MPI_TAG_GRAPH_COUNTS,"RAY_MPI_TAG_GRAPH_COUNTS");
 	core->setMessageTagObjectHandler(plugin,RAY_MPI_TAG_GRAPH_COUNTS,
@@ -4254,7 +4251,7 @@ void Searcher::registerPlugin(ComputeCore*core){
 		__GetAdapter(Searcher,RAY_MPI_TAG_REQUEST_VERTEX_COVERAGE_AND_COLORS));
 	core->setMessageTagSymbol(m_plugin,RAY_MPI_TAG_REQUEST_VERTEX_COVERAGE_AND_COLORS,
 		"RAY_MPI_TAG_REQUEST_VERTEX_COVERAGE_AND_COLORS");
-	
+
 	RAY_MPI_TAG_VIRTUAL_COLOR_DATA=core->allocateMessageTagHandle(m_plugin);
 	core->setMessageTagObjectHandler(m_plugin,RAY_MPI_TAG_VIRTUAL_COLOR_DATA,
 		__GetAdapter(Searcher,RAY_MPI_TAG_VIRTUAL_COLOR_DATA));
@@ -4340,7 +4337,7 @@ void Searcher::resolveSymbols(ComputeCore*core){
 	RAY_MPI_TAG_ADD_COLORS=core->getMessageTagFromSymbol(m_plugin,"RAY_MPI_TAG_ADD_COLORS");
 	RAY_MPI_TAG_ADD_KMER_COLOR_REPLY=core->getMessageTagFromSymbol(m_plugin,"RAY_MPI_TAG_ADD_KMER_COLOR_REPLY");
 	RAY_MPI_TAG_SEARCHER_CLOSE=core->getMessageTagFromSymbol(m_plugin,"RAY_MPI_TAG_SEARCHER_CLOSE");
-	
+
 	RAY_MPI_TAG_REQUEST_VERTEX_COVERAGE_AND_COLORS=core->getMessageTagFromSymbol(m_plugin,"RAY_MPI_TAG_REQUEST_VERTEX_COVERAGE_AND_COLORS");
 	RAY_MPI_TAG_REQUEST_VERTEX_COVERAGE_AND_COLORS_REPLY=core->getMessageTagFromSymbol(m_plugin,"RAY_MPI_TAG_REQUEST_VERTEX_COVERAGE_AND_COLORS_REPLY");
 

--- a/code/TaxonomyViewer/GenomeToTaxonLoader.cpp
+++ b/code/TaxonomyViewer/GenomeToTaxonLoader.cpp
@@ -69,7 +69,7 @@ bool GenomeToTaxonLoader::hasNext(){
 	return m_current<m_size;
 }
 
-void GenomeToTaxonLoader::getNext(GenomeIdentifier*genome,TaxonIdentifier*taxon){
+void GenomeToTaxonLoader::getNext(GenomeIdentifier*genome, TaxonIdentifier*taxon){
 
 	string tmpGenome;
 	GenomeIdentifier loadedGenome=0;
@@ -77,11 +77,14 @@ void GenomeToTaxonLoader::getNext(GenomeIdentifier*genome,TaxonIdentifier*taxon)
 
 	m_stream>>tmpGenome>>loadedTaxon;
 
-  //sdbm algorithm implementation http://www.cse.yorku.ca/~oz/hash.html
-  for (string::const_iterator it = tmpGenome.begin();it!= tmpGenome.end();++it){
-    loadedGenome = ((int) *it) + (loadedGenome << 6)  + (loadedGenome << 16) - loadedGenome ;
-  }
-  loadedGenome = loadedGenome - ((loadedGenome / COLOR_NAMESPACE_MULTIPLIER)*COLOR_NAMESPACE_MULTIPLIER);
+	//sdbm algorithm implementation http://www.cse.yorku.ca/~oz/hash.html
+	for (string::const_iterator it = tmpGenome.begin();it!= tmpGenome.end();++it){
+		loadedGenome = ((int) *it) + (loadedGenome << 6)  + (loadedGenome << 16) - loadedGenome ;
+	}
+
+	loadedGenome = loadedGenome - ((loadedGenome / COLOR_NAMESPACE_MULTIPLIER)*COLOR_NAMESPACE_MULTIPLIER);
+
+	// cout << "genome " << loadedGenome << " linked to taxon " << loadedTaxon << endl;
 
 	(*genome)=loadedGenome;
 	(*taxon)=loadedTaxon;
@@ -91,5 +94,6 @@ void GenomeToTaxonLoader::getNext(GenomeIdentifier*genome,TaxonIdentifier*taxon)
 	if(m_current== m_size){
 		m_stream.close();
 	}
+
 }
 

--- a/code/TaxonomyViewer/GenomeToTaxonLoader.cpp
+++ b/code/TaxonomyViewer/GenomeToTaxonLoader.cpp
@@ -33,14 +33,14 @@ void GenomeToTaxonLoader::load(string file){
 	m_size=0;
 
 	m_stream.open(file.c_str());
-	
+
 	if(!m_stream){
 		cout<<"File "<<file<<" is invalid."<<endl;
 
 		m_stream.close();
 
 	}
-	
+
 	int count=0;
 
 	while(!m_stream.eof()){
@@ -54,10 +54,6 @@ void GenomeToTaxonLoader::load(string file){
 			if(count==2){
 				count=0;
 				m_size++;
-
-				if(m_size % STEPPING == 0){
-					cout<<"GenomeToTaxonLoader::load "<<m_size<<endl;
-				}
 			}
 		}
 
@@ -67,7 +63,6 @@ void GenomeToTaxonLoader::load(string file){
 
 	m_stream.open(file.c_str());
 
-	cout<<"File "<<file<<" has "<<m_size<<" entries"<<endl;
 }
 
 bool GenomeToTaxonLoader::hasNext(){
@@ -76,14 +71,17 @@ bool GenomeToTaxonLoader::hasNext(){
 
 void GenomeToTaxonLoader::getNext(GenomeIdentifier*genome,TaxonIdentifier*taxon){
 
-	if(m_current % STEPPING == 0){
-		cout<<"GenomeToTaxonLoader::getNext "<<m_current<<"/"<<m_size<<endl;
-	}
-
-	GenomeIdentifier loadedGenome;
+	string tmpGenome;
+	GenomeIdentifier loadedGenome=0;
 	TaxonIdentifier loadedTaxon;
 
-	m_stream>>loadedGenome>>loadedTaxon;
+	m_stream>>tmpGenome>>loadedTaxon;
+
+  //sdbm algorithm implementation http://www.cse.yorku.ca/~oz/hash.html
+  for (string::const_iterator it = tmpGenome.begin();it!= tmpGenome.end();++it){
+    loadedGenome = ((int) *it) + (loadedGenome << 6)  + (loadedGenome << 16) - loadedGenome ;
+  }
+  loadedGenome = loadedGenome - ((loadedGenome / COLOR_NAMESPACE_MULTIPLIER)*COLOR_NAMESPACE_MULTIPLIER);
 
 	(*genome)=loadedGenome;
 	(*taxon)=loadedTaxon;

--- a/code/TaxonomyViewer/GenomeToTaxonLoader.h
+++ b/code/TaxonomyViewer/GenomeToTaxonLoader.h
@@ -25,7 +25,7 @@
 #include "types.h"
 
 #include <code/Mock/constants.h>
-
+#include <code/Searcher/ColorSet.h>
 #include <RayPlatform/core/types.h>
 
 #include <string>

--- a/code/TaxonomyViewer/GenomeToTaxonLoader.h
+++ b/code/TaxonomyViewer/GenomeToTaxonLoader.h
@@ -39,7 +39,7 @@ using namespace std;
  * \author Sébastien Boisvert
  */
 class GenomeToTaxonLoader{
-	
+
 	ifstream m_stream;
 
 	int STEPPING;

--- a/code/TaxonomyViewer/TaxonomyViewer.cpp
+++ b/code/TaxonomyViewer/TaxonomyViewer.cpp
@@ -344,11 +344,11 @@ void TaxonomyViewer::loadTree(){
 			}
 
 			if((m_loadAllTree || (m_taxonsForPhylogeny.count(child) > 0)) && parent!=child){
-				
+
 				m_taxonsForPhylogeny.insert(parent);
 
 				m_treeChildren[parent].insert(child);
-	
+
 				m_treeParents[child]=parent;
 			}
 		}
@@ -382,8 +382,7 @@ void TaxonomyViewer::gatherKmerObservations(){
 	iterator.constructor(m_subgraph,m_parameters->getWordSize(),m_parameters);
 
 	//* only fetch half of the iterated things because we just need one k-mer
-	// for any pair of reverse-complement k-mers 
-	
+	// for any pair of reverse-complement k-mers
 	int parity=0;
 
 	map<CoverageDepth,LargeCount> frequencies;
@@ -396,7 +395,7 @@ void TaxonomyViewer::gatherKmerObservations(){
 
 		Vertex*node=iterator.next();
 		Kmer key=*(iterator.getKey());
-		
+
 		if(parity==0){
 			parity=1;
 		}else if(parity==1){
@@ -432,7 +431,6 @@ void TaxonomyViewer::gatherKmerObservations(){
 		#endif
 
 		// at this point, we have a nicely assembled k-mer
-		
 		int kmerCoverage=node->getCoverage(&key);
 
 		VirtualKmerColorHandle color=node->getVirtualColor();
@@ -495,7 +493,7 @@ void TaxonomyViewer::gatherKmerObservations(){
 
 		frequencies[count]++;
 	}
-	
+
 /*
  *
  * TODO: move this in colored operation files
@@ -526,7 +524,7 @@ LargeCount TaxonomyViewer::getSelfCount(TaxonIdentifier taxon){
 	if(m_taxonObservations.count(taxon)==0){
 		return 0;
 	}
-	
+
 	return m_taxonObservations[taxon];
 }
 
@@ -559,7 +557,7 @@ void TaxonomyViewer::showObservations_XML(ostream*stream){
 	ostringstream operationBuffer;
 
 	/* build a mashup for the ranks
- * this will contain total at each level */
+	 * this will contain total at each level */
 
 	map<string,LargeCount> rankRecursiveObservations;
 	map<string,LargeCount> rankSelfObservations;
@@ -827,7 +825,7 @@ void TaxonomyViewer::classifySignal(vector<TaxonIdentifier>*taxons,int kmerCover
 	// case 4.
 	// if there is at least 2 taxons and they don't have the same parent
 	//  but they have a common ancestor
-	
+
 
 
 	if(taxons->size()==0){
@@ -856,7 +854,7 @@ void TaxonomyViewer::classifySignal(vector<TaxonIdentifier>*taxons,int kmerCover
 			TaxonIdentifier taxon=taxons->at(i);
 
 			if(m_treeParents.count(taxon)==0){
-				
+
 				cout<<"Warning: Taxon "<<taxon<<" is not in the tree"<<endl;
 				continue;
 			}
@@ -868,7 +866,7 @@ void TaxonomyViewer::classifySignal(vector<TaxonIdentifier>*taxons,int kmerCover
 		}
 
 		if(parentCount.size()==1){ // only 1 common ancestor, easy
-			
+
 			#ifdef CONFIG_ASSERT
 			if(!(parentCount.begin()->second == found)){
 				cout<<"Error: taxons: "<<taxons->size()<<", parentCount: "<<parentCount.size()<<" 1 element with "<<parentCount.begin()->second<<" taxons"<<endl;
@@ -939,15 +937,15 @@ TaxonIdentifier TaxonomyViewer::findCommonAncestor(vector<TaxonIdentifier>*taxon
 
 			// we found a common ancestor
 			// this is the deepest
-			if(counts[parent]==(int)currentTaxons.size()){ 
+			if(counts[parent]==(int)currentTaxons.size()){
 				return parent;
 			}
-			
+
 			currentTaxons[i]=parent; // update it
 		}
 
 		if(blocked==(int)currentTaxons.size()){ // this will happen if it is not a tree
-			
+
 			cout<<"Error, this is not a tree, blocked: "<<blocked<<" currentTaxons: "<<currentTaxons.size()<<endl;
 			break;
 		}
@@ -996,7 +994,7 @@ void TaxonomyViewer::loadTaxonNames(){
 string TaxonomyViewer::getTaxonName(TaxonIdentifier taxon){
 	if(m_taxonNames.count(taxon)>0){
 		string value=m_taxonNames[taxon];
-		
+
 		for(int i=0;i<(int)value.length();i++){
 
 			char symbol=value[i];
@@ -1084,7 +1082,7 @@ void TaxonomyViewer::getTaxonPathFromRoot(TaxonIdentifier taxon,vector<TaxonIden
 
 	while(m_treeParents.count(current)>0){
 		TaxonIdentifier parent=m_treeParents[current];
-	
+
 		current=parent;
 
 		reversePath.push_back(current);
@@ -1253,7 +1251,7 @@ void TaxonomyViewer::extractColorsForPhylogeny(){
 
 	//* only fetch half of the iterated things because we just need one k-mer
 	// for any pair of reverse-complement k-mers 
-	
+
 	int parity=0;
 
 	while(iterator.hasNext()){
@@ -1280,9 +1278,9 @@ void TaxonomyViewer::extractColorsForPhylogeny(){
 			j!=physicalColors->end();j++){
 
 			PhysicalKmerColor physicalColor=*j;
-	
+
 			PhysicalKmerColor nameSpace=physicalColor/COLOR_NAMESPACE_MULTIPLIER;
-		
+
 			if(nameSpace==COLOR_NAMESPACE_PHYLOGENY){
 				PhysicalKmerColor colorForPhylogeny=physicalColor % COLOR_NAMESPACE_MULTIPLIER;
 
@@ -1294,7 +1292,7 @@ void TaxonomyViewer::extractColorsForPhylogeny(){
 			}
 		}
 	}
-		
+
 	cout<<"Rank "<<m_rank<<" has exactly "<<m_colorsForPhylogeny.size()<<" k-mer physical colors for the phylogeny."<<endl;
 	cout<<endl;
 

--- a/code/TaxonomyViewer/TaxonomyViewer.cpp
+++ b/code/TaxonomyViewer/TaxonomyViewer.cpp
@@ -57,9 +57,9 @@ void TaxonomyViewer::call_RAY_MASTER_MODE_PHYLOGENY_MAIN(){
 
 		Message*message=m_inbox->at(0);
 		call_RAY_MPI_TAG_TAXON_OBSERVATIONS(message);
-	
+
 	}else if(m_inbox->hasMessage(RAY_MPI_TAG_LOADED_TAXONS)){
-		
+
 		m_ranksThatLoadedTaxons++;
 
 		#ifdef CONFIG_ASSERT
@@ -67,7 +67,7 @@ void TaxonomyViewer::call_RAY_MASTER_MODE_PHYLOGENY_MAIN(){
 		#endif
 
 		#ifdef DEBUG_PHYLOGENY
-		cout<<"[phylogeny] m_ranksThatLoadedTaxons -> "<<m_ranksThatLoadedTaxons<<endl;
+		cout<<"[phylogeny] [taxon] m_ranksThatLoadedTaxons -> "<<m_ranksThatLoadedTaxons<<endl;
 		#endif
 
 		if(m_ranksThatLoadedTaxons==m_size){
@@ -99,7 +99,7 @@ void TaxonomyViewer::call_RAY_MASTER_MODE_PHYLOGENY_MAIN(){
 		m_taxonObservations=m_taxonObservationsMaster;
 
 		//cout<<"Global observations"<<endl;
-	
+
 		//showObservations(&cout);
 
 		ostringstream hitFile;
@@ -158,7 +158,7 @@ void TaxonomyViewer::call_RAY_SLAVE_MODE_PHYLOGENY_MAIN(){
 		extractColorsForPhylogeny();
 
 	}else if(!m_loadedTaxonsForPhylogeny){
-	
+
 		loadTaxons();
 
 	}else if(!m_sentTaxonsToMaster){
@@ -166,7 +166,7 @@ void TaxonomyViewer::call_RAY_SLAVE_MODE_PHYLOGENY_MAIN(){
 		sendTaxonsToMaster();
 
 	}else if(!m_sentTaxonControlMessage){
-		
+
 		#ifdef DEBUG_PHYLOGENY
 		cout<<"Sending control message"<<endl;
 		#endif
@@ -177,9 +177,9 @@ void TaxonomyViewer::call_RAY_SLAVE_MODE_PHYLOGENY_MAIN(){
 		m_sentTaxonControlMessage=true;
 
 		m_synced=false;
-	
+
 	}else if(m_inbox->hasMessage(RAY_MPI_TAG_SYNCED_TAXONS)){
-	
+
 		copyTaxonsFromSecondaryTable();
 
 		cout<<"Rank "<<m_rank<<" has "<<m_taxonsForPhylogeny.size()<<" taxons after syncing with master"<<endl;
@@ -192,13 +192,13 @@ void TaxonomyViewer::call_RAY_SLAVE_MODE_PHYLOGENY_MAIN(){
 	}else if(!m_loadedTree){
 
 		loadTree();
-	
+
 	}else if(!m_gatheredObservations){
-	
+
 		gatherKmerObservations();
 
 	}else if(!m_syncedTree){
-		
+
 		sendTreeCounts();
 
 	}else if(m_outbox->size()==0){
@@ -214,7 +214,7 @@ void TaxonomyViewer::call_RAY_SLAVE_MODE_PHYLOGENY_MAIN(){
 
 void TaxonomyViewer::sendTreeCounts(){
 	if(m_messageReceived && m_countIterator==m_taxonObservations.end()){
-	
+
 		m_syncedTree=true;
 
 	}else if(!m_messageSent){
@@ -244,7 +244,7 @@ void TaxonomyViewer::sendTreeCounts(){
 			buffer[bufferPosition++]=count;
 			m_countIterator++;
 		}
-		
+
 		#ifdef CONFIG_ASSERT
 		assert(bufferPosition!=0);
 		#endif
@@ -305,7 +305,7 @@ void TaxonomyViewer::call_RAY_MPI_TAG_TOUCH_TAXON(Message*message){
 }
 
 void TaxonomyViewer::loadTree(){
-	
+
 	if(!m_parameters->hasOption("-with-taxonomy")){
 		m_loadedTree=true;
 
@@ -333,7 +333,7 @@ void TaxonomyViewer::loadTree(){
 
 			TaxonIdentifier parent;
 			TaxonIdentifier child;
-	
+
 			loader.getNext(&parent,&child);
 
 			if(parent==child && taxonsWithWarning.count(parent) == 0){
@@ -445,16 +445,16 @@ void TaxonomyViewer::gatherKmerObservations(){
 			j!=physicalColors->end();j++){
 
 			PhysicalKmerColor physicalColor=*j;
-	
+
 			PhysicalKmerColor nameSpace=physicalColor/COLOR_NAMESPACE_MULTIPLIER;
-		
+
 			// associated with -with-taxonomy
 			if(nameSpace==COLOR_NAMESPACE_PHYLOGENY){
 				PhysicalKmerColor colorForPhylogeny=physicalColor % COLOR_NAMESPACE_MULTIPLIER;
 
 				#ifdef CONFIG_ASSERT
 				if(m_colorsForPhylogeny.count(colorForPhylogeny)==0){
-					//cout<<"Error: color "<<colorForPhylogeny<<" should be in m_colorsForPhylogeny which contains "<<m_colorsForPhylogeny.size()<<endl;
+					cout<<"Error: color "<<colorForPhylogeny<<" should be in m_colorsForPhylogeny which contains "<<m_colorsForPhylogeny.size()<<endl;
 				}
 				#endif
 
@@ -702,7 +702,7 @@ void TaxonomyViewer::showObservations_XML(ostream*stream){
 		}
 
 		operationBuffer<<"<coloredProportionInRank>"<<coloredRatioInRank<<"</coloredProportionInRank>";
-		
+
 		operationBuffer<<"</recursive>"<<endl;
 
 		operationBuffer<<"</entry>"<<endl;
@@ -716,7 +716,7 @@ void TaxonomyViewer::showObservations_XML(ostream*stream){
 			ostringstream theFile;
 			theFile<<m_parameters->getPrefix()<<"/BiologicalAbundances/";
 			theFile<<"0.Profile.TaxonomyRank="<<rank<<".tsv";
-	
+
 			string tsvFile=theFile.str();
 			tsvFiles[rank]=fopen(tsvFile.c_str(),"a");
 
@@ -738,7 +738,7 @@ void TaxonomyViewer::showObservations_XML(ostream*stream){
 
 	// close tsv files
 	for(map<string,FILE*>::iterator i=tsvFiles.begin();i!=tsvFiles.end();i++){
-	
+
 		string rank=i->first;
 		FILE*file=i->second;
 
@@ -772,7 +772,7 @@ LargeCount TaxonomyViewer::getRecursiveCount(TaxonIdentifier taxon){
 	if(m_treeChildren.count(taxon)>0){
 		for(set<TaxonIdentifier>::iterator i=m_treeChildren[taxon].begin();
 			i!=m_treeChildren[taxon].end();i++){
-			
+
 			TaxonIdentifier child=*i;
 
 			count+=getRecursiveCount(child);
@@ -1063,8 +1063,6 @@ string TaxonomyViewer::getTaxonRank(TaxonIdentifier taxon){
 
 void TaxonomyViewer::printTaxonPath(TaxonIdentifier taxon,vector<TaxonIdentifier>*path,ostream*stream){
 
-	//cout<<"Taxon= "<<taxon<<endl;
-
 	for(int i=0;i<(int)path->size();i++){
 
 		TaxonIdentifier taxon=(*path)[i];
@@ -1130,7 +1128,7 @@ void TaxonomyViewer::loadTaxons(){
 	genomeToTaxonUnit.load(genomeToTaxonFile);
 
 	while(genomeToTaxonUnit.hasNext()){
-	
+
 		GenomeIdentifier genome;
 		TaxonIdentifier taxon;
 
@@ -1138,7 +1136,6 @@ void TaxonomyViewer::loadTaxons(){
 
 		if(m_colorsForPhylogeny.count(genome)>0){
 			m_taxonsForPhylogeny.insert(taxon);
-			
 			m_genomeToTaxon[genome]=taxon;
 		}
 	}
@@ -1182,7 +1179,7 @@ void TaxonomyViewer::sendTaxonsFromMaster(){
 			bufferPosition++;
 			m_taxonIterator++;
 		}
-		
+
 		#ifdef CONFIG_ASSERT
 		assert(bufferPosition!=0);
 		#endif
@@ -1197,7 +1194,6 @@ void TaxonomyViewer::sendTaxonsFromMaster(){
 		m_responses++;
 
 		if(m_responses==m_size){
-	
 			m_messageSent=false;
 		}
 	}
@@ -1210,7 +1206,6 @@ void TaxonomyViewer::sendTaxonsToMaster(){
 	if(m_messageReceived && m_taxonIterator==m_taxonsForPhylogeny.end()){
 
 		m_sentTaxonsToMaster=true;
-	
 		m_sentTaxonControlMessage=false;
 
 	}else if(!m_messageSent){
@@ -1231,7 +1226,7 @@ void TaxonomyViewer::sendTaxonsToMaster(){
 			bufferPosition++;
 			m_taxonIterator++;
 		}
-		
+
 		#ifdef CONFIG_ASSERT
 		assert(bufferPosition!=0);
 		#endif

--- a/code/VerticesExtractor/GridTable.cpp
+++ b/code/VerticesExtractor/GridTable.cpp
@@ -40,8 +40,6 @@ void GridTable::constructor(int rank,Parameters*parameters){
 	m_parameters=parameters;
 	m_size=0;
 
-	showMemoryUsage(rank);
-
 	uint64_t buckets=m_parameters->getNumberOfBuckets();
 	int bucketsPerGroup=m_parameters->getNumberOfBucketsPerGroup();
 	double loadFactorThreshold=m_parameters->getLoadFactorThreshold();


### PR DESCRIPTION
Merge @cdash04 code that fix the profiling module of Ray for the new NCBI fasta sequence header.

Indeed NCBI has phase out the GI sequence identifier and replace all the sequence header with only one unique accession identifier.
See https://www.ncbi.nlm.nih.gov/books/NBK431010/#news_03-02-2016-phase-out-of-GI-numbers

The fix include modification of the scripts to download and process the NCBI taxonomy database in order to profile metagenomic datasets with an updated taxonomy when using Ray Meta.

We thank @cdash04 for it's contribution to the Ray code base during it's internship.